### PR TITLE
Update REAMDE - spelling mistakes

### DIFF
--- a/README
+++ b/README
@@ -221,7 +221,7 @@ backgrounds. We are always looking for people interested in helping with code
 development, web-site management, documentation writing, technical
 administration, and whatever else comes up.
 
-If you wish to contribute, please visit the web site http://biopython.org
+If you wish to contribute, please visit the website http://biopython.org
 and join our mailing list: http://biopython.org/wiki/Mailing_lists
 
 


### PR DESCRIPTION
Correcting a spelling mistake in line 224, where "website" was spelled separately as "web site," which was inconsistent with earlier occurrences of the word.